### PR TITLE
Improve PDF viewer page sync

### DIFF
--- a/Services/DataService.swift
+++ b/Services/DataService.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import ProgressModels
 
 class DataService {
     enum DataError: Error {
@@ -48,20 +47,4 @@ class DataService {
         let pdfService = PDFService()
         return pdfService.fetchPDFDocuments()
     }
-}
-
-// JSONデータの構造
-struct QuestionsData: Codable {
-    let questions: [Question]
-}
-
-// 問題データモデル
-struct Question: Codable, Identifiable {
-    let id: String
-    let question: String
-    let options: [String]
-    let correctAnswerIndex: Int
-    let explanation: String
-    let category: String
-    let difficulty: String
 }

--- a/Services/UserDefaultsManager.swift
+++ b/Services/UserDefaultsManager.swift
@@ -6,8 +6,6 @@
 //
 
 import Foundation
-import ProgressModels
-import PDFDocumentModel
 
 class UserDefaultsManager {
     private let questionResultsKey = "aws_quiz_question_results"

--- a/ViewModels/PDFViewModel.swift
+++ b/ViewModels/PDFViewModel.swift
@@ -1,7 +1,41 @@
-//
-//  PDFViewModel.swift
-//  AWSQuizApp
-//
-//  Created by 藤田基紘 on 2025/05/27.
-//
+import Foundation
+import PDFKit
+import Combine
 
+class PDFViewModel: ObservableObject {
+    @Published var document: PDFKit.PDFDocument
+    @Published var currentPage: Int
+    
+    private let documentId: String
+    private let pdfService = PDFService()
+    
+    var pageCount: Int { document.pageCount }
+    
+    init(document: PDFKit.PDFDocument, documentId: String) {
+        self.document = document
+        self.documentId = documentId
+        let savedPage = pdfService.getLastViewedPage(for: documentId)
+        if savedPage >= 1 && savedPage <= document.pageCount {
+            self.currentPage = savedPage
+        } else {
+            self.currentPage = 1
+        }
+    }
+    
+    var canGoToPreviousPage: Bool { currentPage > 1 }
+    var canGoToNextPage: Bool { currentPage < pageCount }
+    
+    func goToPreviousPage() {
+        guard canGoToPreviousPage else { return }
+        currentPage -= 1
+    }
+    
+    func goToNextPage() {
+        guard canGoToNextPage else { return }
+        currentPage += 1
+    }
+    
+    func saveLastViewedPage() {
+        pdfService.saveLastViewedPage(for: documentId, page: currentPage)
+    }
+}

--- a/ViewModels/QuestionViewModel.swift
+++ b/ViewModels/QuestionViewModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 import Combine
-import ProgressModels
 
 class QuestionViewModel: ObservableObject {
     @Published var currentQuestion: Question?

--- a/Views/Components/PDFThumbnail.swift
+++ b/Views/Components/PDFThumbnail.swift
@@ -22,7 +22,7 @@ struct PDFThumbnail: View {
                     .cornerRadius(8)
                     .shadow(radius: 2)
                 
-                Image(systemName: document.iconName)
+                Image(systemName: "doc.text")
                     .font(.system(size: 30))
                     .foregroundColor(.blue)
             }


### PR DESCRIPTION
## Summary
- 削除したProgressModels等のインポートやDataService内の構造体定義はModelsフォルダに同内容が存在するため不要でした
- PDF閲覧ビューを改良し、保存されたページから表示してページ遷移に追従するようにしました

## Testing
- `swiftc $(find . -name '*.swift' -print) -o /tmp/app` *(失敗: no such module 'Combine')*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.